### PR TITLE
Add EdgeTransaction.parentNetworkFee

### DIFF
--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -553,6 +553,7 @@ export type EdgeTransaction = {
   networkFee: string,
   ourReceiveAddresses: Array<string>,
   signedTx: string,
+  parentNetworkFee?: string,
   metadata?: EdgeMetadata,
   otherParams: any,
   wallet?: EdgeCurrencyWallet


### PR DESCRIPTION
For token transactions, this is the fee paid in the parent currency (ETH)