### PR TITLE
Get-Transaction optimize performance

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -95,7 +95,7 @@ export interface CurrencyWalletFileChanged {
     json: any,
     txid: string,
     walletId: string,
-    txidHash: string
+    txFileName: any
   };
 }
 
@@ -111,12 +111,12 @@ export interface CurrencyWalletFilesLoaded {
 }
 
 /**
- * Called when a currency wallet's files have been loaded from disk.
+ * Called when a currency wallet's file names have been loaded from disk.
  */
 export interface CurrencyWalletFileNamesLoaded {
   type: 'CURRENCY_WALLET_FILE_NAMES_LOADED';
   payload: {
-    fileNames: any,
+    txFileNames: any,
     walletId: string
   };
 }

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -33,7 +33,8 @@ export interface CurrencyEngineChangedTxs {
   type: 'CURRENCY_ENGINE_CHANGED_TXS';
   payload: {
     txs: Array<any>,
-    walletId: string
+    walletId: string,
+    txidHashes: any
   };
 }
 
@@ -93,7 +94,8 @@ export interface CurrencyWalletFileChanged {
   payload: {
     json: any,
     txid: string,
-    walletId: string
+    walletId: string,
+    txidHash: string
   };
 }
 
@@ -104,6 +106,17 @@ export interface CurrencyWalletFilesLoaded {
   type: 'CURRENCY_WALLET_FILES_LOADED';
   payload: {
     files: any,
+    walletId: string
+  };
+}
+
+/**
+ * Called when a currency wallet's files have been loaded from disk.
+ */
+export interface CurrencyWalletFileNamesLoaded {
+  type: 'CURRENCY_WALLET_FILE_NAMES_LOADED';
+  payload: {
+    fileNames: any,
     walletId: string
   };
 }
@@ -177,6 +190,7 @@ export type RootAction =
   | CurrencyWalletFiatChanged
   | CurrencyWalletFileChanged
   | CurrencyWalletFilesLoaded
+  | CurrencyWalletFileNamesLoaded
   | CurrencyWalletNameChanged
   | InitAction
   | LoginAction

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -20,6 +20,7 @@ import { filterObject, mergeDeeply } from '../../../util/util.js'
 import { makeShapeshiftApi } from '../../exchange/shapeshift.js'
 import type { ApiInput } from '../../root.js'
 import { makeStorageWalletApi } from '../../storage/storageApi.js'
+import type { TransactionFile } from './currency-wallet-files.js'
 import {
   loadTxFiles,
   renameCurrencyWallet,
@@ -27,6 +28,7 @@ import {
   setCurrencyWalletTxMetadata
 } from './currency-wallet-files.js'
 import type { CurrencyWalletInput } from './currency-wallet-pixie.js'
+import { mergeTx } from './currency-wallet-reducer.js'
 
 const fakeMetadata = {
   bizId: 0,
@@ -35,6 +37,21 @@ const fakeMetadata = {
   name: '',
   notes: ''
 }
+
+const defaultTx = (
+  file: TransactionFile,
+  currencyCode: string
+): EdgeTransaction => ({
+  txid: file.txid,
+  date: file.creationDate,
+  currencyCode: currencyCode,
+  blockHeight: -1,
+  nativeAmount: '0',
+  networkFee: '0',
+  ourReceiveAddresses: [],
+  signedTx: '',
+  otherParams: {}
+})
 
 /**
  * Creates an `EdgeCurrencyWallet` API object.
@@ -147,6 +164,11 @@ export function makeCurrencyWalletApi (
       Object.assign(files, missingFiles)
 
       const out = []
+      for (const selectedTX of slicedTransactions) {
+        const { txidHash } = selectedTX
+        const file = files[txidHash]
+        const tx =
+          txs[file.txid] || mergeTx(defaultTx(file, currencyCode), currencyCode)
         // Skip irrelevant transactions:
         if (!tx.nativeAmount[currencyCode] && !tx.networkFee[currencyCode]) {
           continue

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -147,25 +147,25 @@ export function makeCurrencyWalletApi (
     async getTransactions (opts: any = {}): Promise<Array<EdgeTransaction>> {
       const defaultCurrency = plugin.currencyInfo.currencyCode
       const currencyCode = opts.currencyCode || defaultCurrency
+      const state = input.props.selfState
       // Txid array of all txs
-      const txids = input.props.selfState.txids
+      const txids = state.txids
       // Merged tx data from metadata files and blockchain data
-      const txs = input.props.selfState.txs
+      const txs = state.txs
       const { numIndex = 0, numEntries = txids.length } = opts
       // Decrypted metadata files
-      const files = input.props.selfState.files
+      const files = state.files
       // A sorted list of transaction based on chronological order
-      const sortedTransactions = input.props.selfState.sortedTransactions
+      const sortedTransactions = state.sortedTransactions.sortedList
       const slicedTransactions = sortedTransactions.slice(numIndex, numEntries)
       const missingTxIdHashes = slicedTransactions.filter(
-        ({ txidHash }) => !files[txidHash]
+        txidHash => !files[txidHash]
       )
       const missingFiles = await loadTxFiles(input, missingTxIdHashes)
       Object.assign(files, missingFiles)
 
       const out = []
-      for (const selectedTX of slicedTransactions) {
-        const { txidHash } = selectedTX
+      for (const txidHash of slicedTransactions) {
         const file = files[txidHash]
         const tx =
           txs[file.txid] || mergeTx(defaultTx(file, currencyCode), currencyCode)

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -128,26 +128,25 @@ export function makeCurrencyWalletApi (
     },
 
     async getTransactions (opts: any = {}): Promise<Array<EdgeTransaction>> {
-      // Txid array of all txs
-      const txids = input.props.selfState.txids
-      const { numIndex = 0, numEntries = txids.length } = opts
-      const slicedTxids = txids.slice(numIndex, numEntries)
-      // Decrepted metadata files
-      const files = input.props.selfState.files
-      // Merged tx data from metadata files and blockchain data
-      const txs = input.props.selfState.txs
-
       const defaultCurrency = plugin.currencyInfo.currencyCode
       const currencyCode = opts.currencyCode || defaultCurrency
-      const missingTxids = slicedTxids.filter(txid => !files[txid])
-      const missingFiles = await loadTxFiles(input, missingTxids)
+      // Txid array of all txs
+      const txids = input.props.selfState.txids
+      // Merged tx data from metadata files and blockchain data
+      const txs = input.props.selfState.txs
+      const { numIndex = 0, numEntries = txids.length } = opts
+      // Decrypted metadata files
+      const files = input.props.selfState.files
+      // A sorted list of transaction based on chronological order
+      const sortedTransactions = input.props.selfState.sortedTransactions
+      const slicedTransactions = sortedTransactions.slice(numIndex, numEntries)
+      const missingTxIdHashes = slicedTransactions.filter(
+        ({ txidHash }) => !files[txidHash]
+      )
+      const missingFiles = await loadTxFiles(input, missingTxIdHashes)
       Object.assign(files, missingFiles)
 
       const out = []
-      for (const txid of slicedTxids) {
-        const tx = txs[txid]
-        const file = files[txid]
-
         // Skip irrelevant transactions:
         if (!tx.nativeAmount[currencyCode] && !tx.networkFee[currencyCode]) {
           continue

--- a/src/modules/currency/wallet/currency-wallet-callbacks.js
+++ b/src/modules/currency/wallet/currency-wallet-callbacks.js
@@ -93,7 +93,7 @@ export function makeCurrencyWalletCallbacks (
       }
       const { state } = input.props
       const existingTxs = input.props.selfState.txs
-      const txidHashes = []
+      const txidHashes = {}
       const files = input.props.selfState.files || {}
       const fileNames = input.props.selfState.fileNames || []
       const defaultCurrency = input.props.selfState.currencyInfo.currencyCode
@@ -120,7 +120,7 @@ export function makeCurrencyWalletCallbacks (
         } else if (decryptedMetadata) {
           changed.push(combinedTx)
         }
-        txidHashes.push({ txidHash, timestamp: combinedTx.date })
+        txidHashes[txidHash] = combinedTx.date
       }
       // Side Effect
       input.props.dispatch({

--- a/src/modules/currency/wallet/currency-wallet-callbacks.js
+++ b/src/modules/currency/wallet/currency-wallet-callbacks.js
@@ -107,7 +107,7 @@ export function makeCurrencyWalletCallbacks (
 
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
         const isNew = !fileNames[txidHash]
-        const decryptedMetadata = files[txid]
+        const decryptedMetadata = files[txidHash]
         const combinedTx = combineTxWithFile(
           input,
           tx,

--- a/src/modules/currency/wallet/currency-wallet-files.js
+++ b/src/modules/currency/wallet/currency-wallet-files.js
@@ -16,6 +16,10 @@ import { combineTxWithFile } from './currency-wallet-api.js'
 import { forEachListener } from './currency-wallet-callbacks.js'
 import type { CurrencyWalletInput } from './currency-wallet-pixie.js'
 
+const LEGACY_MAP_FILE = 'fixedLegacyFileNames.json'
+const WALLET_NAME_FILE = 'WalletName.json'
+const CURRENCY_FILE = 'Currency.json'
+
 type TransactionFile = {
   txid: string,
   internal: boolean,
@@ -129,7 +133,7 @@ export function renameCurrencyWallet (
   const { dispatch, state } = input.props
 
   return getStorageWalletFolder(state, walletId)
-    .file('WalletName.json')
+    .file(WALLET_NAME_FILE)
     .setText(JSON.stringify({ walletName: name }))
     .then(() =>
       dispatch({
@@ -154,7 +158,7 @@ export function setCurrencyWalletFiat (
   }
 
   return getStorageWalletFolder(state, walletId)
-    .file('Currency.json')
+    .file(CURRENCY_FILE)
     .setText(JSON.stringify({ fiat: fiatCurrencyCode }))
     .then(() =>
       dispatch({
@@ -172,7 +176,7 @@ function loadFiatFile (input: CurrencyWalletInput, folder) {
   const { dispatch } = input.props
 
   return folder
-    .file('Currency.json')
+    .file(CURRENCY_FILE)
     .getText()
     .then(text => {
       const file = JSON.parse(text)
@@ -196,7 +200,7 @@ function loadNameFile (input: CurrencyWalletInput, folder) {
   const { dispatch } = input.props
 
   return folder
-    .file('WalletName.json')
+    .file(WALLET_NAME_FILE)
     .getText()
     .then(text => JSON.parse(text).walletName)
     .catch(async e => {

--- a/src/modules/currency/wallet/currency-wallet-files.js
+++ b/src/modules/currency/wallet/currency-wallet-files.js
@@ -15,7 +15,6 @@ import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { combineTxWithFile } from './currency-wallet-api.js'
 import { forEachListener } from './currency-wallet-callbacks.js'
 import type { CurrencyWalletInput } from './currency-wallet-pixie.js'
-import type { TxIdHash } from './currency-wallet-reducer.js'
 
 const LEGACY_MAP_FILE = 'fixedLegacyFileNames.json'
 const WALLET_NAME_FILE = 'WalletName.json'
@@ -245,7 +244,7 @@ function fetchBackupName (
  */
 export async function loadTxFiles (
   input: CurrencyWalletInput,
-  txIdHashes: Array<TxIdHash>
+  txIdHashes: Array<string>
 ): any {
   const walletId = input.props.id
   const folder = getStorageWalletFolder(input.props.state, walletId)
@@ -256,7 +255,7 @@ export async function loadTxFiles (
 
   const getFiles = (folderName, cb) =>
     Promise.all(
-      txIdHashes.map(({ txidHash }) =>
+      txIdHashes.map(txidHash =>
         folder
           .folder(folderName)
           .file(fileNames[txidHash].fileName)

--- a/src/modules/currency/wallet/currency-wallet-files.js
+++ b/src/modules/currency/wallet/currency-wallet-files.js
@@ -257,7 +257,7 @@ export async function loadTxFiles (
     Promise.all(
       fileNames.map(fileName =>
         folder
-          .folder('folderName')
+          .folder(folderName)
           .file(fileName)
           .getText()
           .then(text => JSON.parse(text))

--- a/src/modules/currency/wallet/currency-wallet-pixie.js
+++ b/src/modules/currency/wallet/currency-wallet-pixie.js
@@ -104,7 +104,7 @@ export default combinePixies({
           !input.props.selfOutput ||
           !input.props.selfOutput.api ||
           !input.props.selfState.fiatLoaded ||
-          !input.props.selfState.filesLoaded
+          !input.props.selfState.fileNamesLoaded
         ) {
           return
         }

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -94,11 +94,11 @@ const currencyWalletReducer = buildReducer({
       }
       case 'CURRENCY_WALLET_FILE_NAMES_LOADED': {
         const { txFileNames } = action.payload
-        const txidHashes = {}
+        const newTxidHashes = {}
         Object.keys(txFileNames).map(txidHash => {
-          txidHashes[txidHash] = txFileNames[txidHash].timestamp
+          newTxidHashes[txidHash] = txFileNames[txidHash].timestamp
         })
-        return sortTxs(txidHashes, txidHashes)
+        return sortTxs(txidHashes, newTxidHashes)
       }
     }
     return state

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -24,7 +24,6 @@ export interface CurrencyWalletState {
   fiat: string;
   fiatLoaded: boolean;
   files: { [txid: string]: Object };
-  filesLoaded: boolean;
   fileNames: { [txidHash: string]: number };
   fileNamesLoaded: boolean;
   sortedTransactions: SortedTransactionList;
@@ -77,9 +76,6 @@ const currencyWalletReducer = buildReducer({
     return state
   },
 
-  filesLoaded (state = false, action) {
-    return action.type === 'CURRENCY_WALLET_FILES_LOADED' ? true : state
-  },
 
   sortedTransactions (state = [], action: RootAction, next: CurrencyWalletNext) {
     switch (action.type) {


### PR DESCRIPTION
Use a much more "lazy" approach for loading the transaction data from disk.
We are currently loading all of transaction data from disk to memory when on login.
The problem with that, is that loading the TX data from disk requires decrypting which takes tons of CPU cycles and time and also we really don't need the TX until we move into the transaction list scene.

The main changes are:
1. On startup, load only the TX file names without decrypting them.
2. Only load and decrypt the TX data if the user ask the TX using the "getTransaction" method.
3. When getting a TX from the plugin, call "onTransactionChange" only if we never created a file which removes tons of pointless calls.
