### PR TITLE
super quick and dirty fix to load all token transactions

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -158,10 +158,19 @@ export function makeCurrencyWalletApi (
       // A sorted list of transaction based on chronological order
       const sortedTransactions = state.sortedTransactions.sortedList
       // Quick fix for Tokens
-      const slicedTransactions =
-        defaultCurrency === 'ETH'
-          ? sortedTransactions
-          : sortedTransactions.slice(numIndex, numEntries)
+      const metaTokens = plugin.currencyInfo.metaTokens
+      let slice = true
+      if (defaultCurrency === 'ETH' && currencyCode !== 'ETH') {
+        for (const token of metaTokens) {
+          if (currencyCode === token.currencyCode) {
+            slice = false
+            break
+          }
+        }
+      }
+      const slicedTransactions = slice
+        ? sortedTransactions.slice(numIndex, numEntries)
+        : sortedTransactions
       const missingTxIdHashes = slicedTransactions.filter(
         txidHash => !files[txidHash]
       )

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -157,7 +157,11 @@ export function makeCurrencyWalletApi (
       const files = state.files
       // A sorted list of transaction based on chronological order
       const sortedTransactions = state.sortedTransactions.sortedList
-      const slicedTransactions = sortedTransactions.slice(numIndex, numEntries)
+      // Quick fix for Tokens
+      const slicedTransactions =
+        defaultCurrency === 'ETH'
+          ? sortedTransactions
+          : sortedTransactions.slice(numIndex, numEntries)
       const missingTxIdHashes = slicedTransactions.filter(
         txidHash => !files[txidHash]
       )

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -158,14 +158,12 @@ export function makeCurrencyWalletApi (
       // A sorted list of transaction based on chronological order
       const sortedTransactions = state.sortedTransactions.sortedList
       // Quick fix for Tokens
-      const metaTokens = plugin.currencyInfo.metaTokens
-      let slice = true
-      if (defaultCurrency === 'ETH' && currencyCode !== 'ETH') {
-        for (const token of metaTokens) {
-          if (currencyCode === token.currencyCode) {
-            slice = false
-            break
-          }
+      const allInfos = input.props.state.currency.infos
+      let slice = false
+      for (const currencyInfo of allInfos) {
+        if (currencyCode === currencyInfo.currencyCode) {
+          slice = true
+          break
         }
       }
       const slicedTransactions = slice


### PR DESCRIPTION
We currently have a problem that because the sortedList doesn't contains the currencyCode, we have no way to know which files are pure Ether and which might have Token Tx inside of them.
So we will just load all of them.