### PR TITLE
Fix dead Save on txdetails

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -116,7 +116,7 @@ const currencyWalletReducer = buildReducer({
       case 'CURRENCY_WALLET_FILE_CHANGED': {
         const { txFileName } = action.payload
         const { txidHash, timestamp, fileName } = txFileName
-        if (!state[txidHash] || timestamp < state[fileName].timestamp) {
+        if (!state[txidHash] || timestamp < state[txidHash].timestamp) {
           state[txidHash] = { timestamp, fileName }
         }
         return state


### PR DESCRIPTION
Incorrect deference of `state` variable with `fileName` instead of `txidHash` resulted in an undefined `timestamp` value which would fail the entire action.