### PR TITLE
Adding props to EdgeParsedUri

### DIFF
--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -597,6 +597,8 @@ export type EdgeCurrencyInfo = {
 }
 
 export type EdgeParsedUri = {
+  token?: EdgeTokenInfo,
+  privateKey?: string,
   publicAddress?: string,
   segwitAddress?: string,
   nativeAmount?: string,


### PR DESCRIPTION
Add "token" and "privateKey" as optional props to "EdgeParsedUri" for the features:
1. Adding tokens
2. Sweeping private keys