### PR TITLE
One-liner fix for getTransactions when query doesn't start at zero

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -154,7 +154,7 @@ export function makeCurrencyWalletApi (
         }
       }
       const slicedTransactions = slice
-        ? sortedTransactions.slice(numIndex, numEntries)
+        ? sortedTransactions.slice(numIndex, numIndex + numEntries)
         : sortedTransactions
       const missingTxIdHashes = slicedTransactions.filter(
         txidHash => !files[txidHash]


### PR DESCRIPTION
Add numEntries to numIndex to get full range requested