### PR TITLE
Change createPrivateKey and derivePublicKey to `Object` instead of `{}`

### DIFF
--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -703,8 +703,8 @@ export type EdgeCurrencyEngine = {
 export type EdgeCurrencyPlugin = {
   +pluginName: string,
   +currencyInfo: EdgeCurrencyInfo,
-  createPrivateKey(walletType: string): {},
-  derivePublicKey(walletInfo: EdgeWalletInfo): {},
+  createPrivateKey(walletType: string): Object,
+  derivePublicKey(walletInfo: EdgeWalletInfo): Object,
   makeEngine(
     walletInfo: EdgeWalletInfo,
     options: EdgeCurrencyEngineOptions


### PR DESCRIPTION
Fixes flow errors when code actually tries to dereference returned keys.