### PR TITLE
Fix Edge login bugs

### DIFF
--- a/src/modules/login/edge.js
+++ b/src/modules/login/edge.js
@@ -53,9 +53,15 @@ function onReply (ai: ApiInput, subscription, reply, appId, opts) {
     if (login == null) {
       throw new Error(`Cannot find requested appId: "${appId}"`)
     }
-    syncLogin(ai, loginTree, login).then(loginTree => {
-      opts.onLogin(void 0, loginTree)
-    })
+    syncLogin(ai, loginTree, login)
+      .then(loginTree => {
+        opts.onLogin(void 0, loginTree)
+      })
+      .catch(e => {
+        if (opts.onLogin != null) {
+          opts.onLogin(e)
+        }
+      })
   }
 }
 

--- a/src/modules/login/login.js
+++ b/src/modules/login/login.js
@@ -350,7 +350,11 @@ export function syncLogin (
     const request = makeAuthJson(login)
     return authRequest(ai, 'POST', '/v2/login', request).then(reply => {
       const newStashTree = applyLoginReply(stashTree, login.loginKey, reply)
-      const newLoginTree = makeLoginTree(stashTree, login.loginKey, login.appId)
+      const newLoginTree = makeLoginTree(
+        newStashTree,
+        login.loginKey,
+        login.appId
+      )
 
       return loginStore.save(newStashTree).then(() => newLoginTree)
     })


### PR DESCRIPTION
The data on disk might be out of date or missing, so `syncLogin` should use the data from the server instead.

Also, if something goes wrong, properly handle the error instead of creating an unhandled promise rejection.